### PR TITLE
Update boot.py

### DIFF
--- a/scripts/sour-apple-circuitpython/boot.py
+++ b/scripts/sour-apple-circuitpython/boot.py
@@ -1,3 +1,6 @@
-import supervisor
+# the disable_ble_workflow() was removed in CircuitPython 8.2.x release
+# uncomment the lines below if CircuitPython version <= 7.3
 
-supervisor.disable_ble_workflow()
+# import supervisor
+
+# supervisor.disable_ble_workflow()


### PR DESCRIPTION
Commented lines that may cause the device running certain versions of CircuitPython to crash.

Affected versions:
- latest, 8.2.x
